### PR TITLE
add-configure_permitted_parameters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
+  before_action :configure_permitted_parameters, if: :devise_controller?
   protect_from_forgery with: :exception
 
   private
@@ -8,6 +9,14 @@ class ApplicationController < ActionController::Base
     Rails.env.production?
   end
 
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(
+      :sign_up,keys: [:nickname,:first_name,:last_name,:first_name_hurigana,:last_name_hurigana,:birth_year,:birth_month,:birth_day]
+    )
+    devise_parameter_sanitizer.permit(
+      :account_update,keys: [:nickname,:first_name,:last_name,:first_name_hurigana,:last_name_hurigana,:birth_year,:birth_month,:birth_day]
+    )
+  end 
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|


### PR DESCRIPTION
# What
configure_permitted_parameterを定義した
 
# Why
deviseを利用した登録・更新の際に各カラムに値を登録・更新する許可を与えるため