### PR TITLE
add dependent: :destroy

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,9 +4,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  has_one :address
-  has_many :purchases
-  has_many :items
+  has_one :address, dependent: :destroy
+  has_many :purchases, dependent: :destroy
+  has_many :items, dependent: :destroy
   
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   VALID_KATAKANA_REGEX = /\A[\p{katakana}\p{blank}ー－]+\z/

--- a/db/migrate/20200724021743_devise_create_users.rb
+++ b/db/migrate/20200724021743_devise_create_users.rb
@@ -6,7 +6,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.0]
       ## Database authenticatable
       t.string :nickname,             null: false
       t.string :email,                null: false, default: ""
-      t.string :password,             null: false, default: ""
+      t.string :encrypted_password,   null: false, default: ""
       t.string :first_name,           null: false
       t.string :last_name,            null: false
       t.string :first_name_hurigana,  null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,7 +15,7 @@ ActiveRecord::Schema.define(version: 2020_07_24_021743) do
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "nickname", null: false
     t.string "email", default: "", null: false
-    t.string "password", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
     t.string "first_name", null: false
     t.string "last_name", null: false
     t.string "first_name_hurigana", null: false


### PR DESCRIPTION
# What
アソシエーションの定義の際に、dependent: :destroyを追記した。

# Why
親モデル(Userモデル)を削除する時に関連する子モデルも一緒に削除する必要があるため。dependent: :destroyを追記することで、Userモデルの特定のデータを削除した際に、コールバック的に削除したUserモデルデータに関連した子モデルデータを削除することを臨む。